### PR TITLE
feat(future): MARKET order + TP/SL + autoOCO (USDⓈ-M futures)

### DIFF
--- a/nodes/Binance/actions/future/order/order.execute.ts
+++ b/nodes/Binance/actions/future/order/order.execute.ts
@@ -2,41 +2,233 @@ import { IExecuteFunctions } from 'n8n-core';
 import { INodeExecutionData } from 'n8n-workflow';
 import createBinance, { OrderSide_LT } from 'binance-api-node';
 
+function sleep(ms: number) {
+	return new Promise((res) => setTimeout(res, ms));
+}
+
 export async function execute(
 	this: IExecuteFunctions,
 	index: number,
 ): Promise<INodeExecutionData[]> {
 	const credentials = await this.getCredentials('binanceApi', index);
-	const binanceClient = createBinance(credentials);
+	const binanceClient = createBinance(credentials as any);
 
 	const side = this.getNodeParameter('side', index) as string;
 	const symbol = this.getNodeParameter('symbol', index) as string;
 
+	// quick handlers for CLEAR/GET (preserve existing behavior)
 	if (side === 'CLEAR') {
 		const order = await binanceClient.futuresCancelAllOpenOrders({ symbol });
-
 		return this.helpers.returnJsonArray(order as any);
 	}
 
 	if (side === 'GET') {
 		const orders = await binanceClient.futuresOpenOrders({ symbol });
-
 		return this.helpers.returnJsonArray(orders as any);
 	}
 
-	const quantity = this.getNodeParameter('quantity', index) as string;
-	const price = this.getNodeParameter('price', index) as string;
+	// common parameters
+	const quantity = this.getNodeParameter('quantity', index) as any;
+	const price = this.getNodeParameter('price', index) as any;
 	const reduceOnly = this.getNodeParameter('reduceOnly', index) as boolean;
 
-	const order = await binanceClient.futuresOrder({
-		symbol,
-		quantity,
-		price,
-		side: side as OrderSide_LT,
-		type: 'LIMIT',
-		timeInForce: 'GTC',
-		reduceOnly: `${reduceOnly}`,
-	});
+	// new parameters per TЗ
+	const orderType = (this.getNodeParameter('orderType', index) as string) || 'LIMIT';
+	const tpPercent = (this.getNodeParameter('tpPercent', index) as number) || 0;
+	const slPercent = (this.getNodeParameter('slPercent', index) as number) || 0;
+	const autoOco = (this.getNodeParameter('autoOco', index) as boolean) ?? true;
+	const autoOcoTimeout = (this.getNodeParameter('autoOcoTimeout', index) as number) || 30;
+	const workingType = (this.getNodeParameter('workingType', index) as string) || 'MARK_PRICE';
 
-	return this.helpers.returnJsonArray(order as any);
+	// response placeholders
+	let marketOrder: any = null;
+	let takeProfitOrder: any = null;
+	let stopLossOrder: any = null;
+	let autoOcoResult: any = { status: 'not_enabled' };
+
+	// create market or limit order
+	if (orderType === 'MARKET') {
+		// create MARKET order
+		marketOrder = await binanceClient.futuresOrder({
+			symbol,
+			quantity: String(quantity),
+			side: side as OrderSide_LT,
+			type: 'MARKET',
+		});
+
+		// try to obtain entry price (avgPrice) and executed qty; fallback polling if 0
+		let entryPrice: number | undefined =
+			marketOrder && (marketOrder.avgPrice ? Number(marketOrder.avgPrice) : undefined);
+
+		let entryQty: number | undefined =
+			marketOrder && marketOrder.executedQty ? Number(marketOrder.executedQty) : undefined;
+
+		if ((!entryPrice || entryPrice === 0) && marketOrder && marketOrder.orderId) {
+			const maxAttempts = 5;
+			for (let attempt = 0; attempt < maxAttempts; attempt++) {
+				await sleep(500);
+				try {
+					// some binance client libs support fetching order by orderId
+					// this call may throw on some versions — wrap in try/catch
+					const ord = await binanceClient.futuresOrder({
+						symbol,
+						orderId: marketOrder.orderId,
+					} as any);
+					if (ord) {
+						if (ord.avgPrice && Number(ord.avgPrice) > 0) {
+							entryPrice = Number(ord.avgPrice);
+						}
+						if (ord.executedQty) {
+							entryQty = Number(ord.executedQty);
+						}
+					}
+					if (entryPrice && entryPrice > 0) break;
+				} catch (e) {
+					// ignore and retry
+				}
+			}
+		}
+
+		// if still no price, we won't create TP/SL to avoid wrong levels
+		if (!entryPrice || entryPrice === 0) {
+			// fallback: try last trade price (less accurate) — optional, commented out
+			// const trades = await binanceClient.futuresTrades({ symbol, limit: 1 });
+			// if (trades && trades.length) entryPrice = Number(trades[0].price);
+
+			// Return a warning-contained response but keep market order info
+			return this.helpers.returnJsonArray([
+				{
+					json: {
+						error: 'Unable to determine entry price after MARKET order; TP/SL not created',
+						marketOrder,
+					},
+				},
+			]);
+		}
+	} else {
+		// LIMIT (existing behaviour)
+		marketOrder = await binanceClient.futuresOrder({
+			symbol,
+			quantity: String(quantity),
+			price: String(price),
+			side: side as OrderSide_LT,
+			type: 'LIMIT',
+			timeInForce: 'GTC',
+			reduceOnly: `${reduceOnly}`,
+		});
+		// For LIMIT, binance may not provide avgPrice until filled — we will not attempt TP/SL here
+		// unless you want behavior: create conditional orders immediately using price param.
+		// For minimal change, we skip auto-TP/SL for LIMIT in this implementation.
+	}
+
+	// If we have an entry price and TP/SL requested — create conditional orders
+	const entryPriceResolved =
+		marketOrder && (marketOrder.avgPrice || (marketOrder.fills && marketOrder.fills.length ? marketOrder.fills[0].price : undefined));
+
+	let entryPriceNum: number | undefined = undefined;
+	if (entryPriceResolved) {
+		entryPriceNum = Number(entryPriceResolved);
+	}
+
+	// If we created MARKET and have entryPriceNum, create TP/SL
+	if (orderType === 'MARKET' && entryPriceNum && (tpPercent > 0 || slPercent > 0)) {
+		const isBuy = side === 'BUY';
+		let tpPrice: number | undefined = undefined;
+		let slPrice: number | undefined = undefined;
+
+		if (tpPercent > 0) {
+			tpPrice = isBuy ? entryPriceNum * (1 + tpPercent / 100) : entryPriceNum * (1 - tpPercent / 100);
+		}
+		if (slPercent > 0) {
+			slPrice = isBuy ? entryPriceNum * (1 - slPercent / 100) : entryPriceNum * (1 + slPercent / 100);
+		}
+
+		const oppositeSide = isBuy ? 'SELL' : 'BUY';
+
+		// create TAKE_PROFIT_MARKET if needed
+		if (tpPrice) {
+			try {
+				takeProfitOrder = await binanceClient.futuresOrder({
+					symbol,
+					side: oppositeSide as OrderSide_LT,
+					type: 'TAKE_PROFIT_MARKET',
+					stopPrice: String(tpPrice),
+					closePosition: 'true',
+					workingType,
+				} as any);
+			} catch (e: any) {
+				// capture error, but continue attempting SL
+				takeProfitOrder = { error: (e && e.message) ? e.message : e };
+			}
+		}
+
+		// create STOP_MARKET if needed
+		if (slPrice) {
+			try {
+				stopLossOrder = await binanceClient.futuresOrder({
+					symbol,
+					side: oppositeSide as OrderSide_LT,
+					type: 'STOP_MARKET',
+					stopPrice: String(slPrice),
+					closePosition: 'true',
+					workingType,
+				} as any);
+			} catch (e: any) {
+				stopLossOrder = { error: (e && e.message) ? e.message : e };
+			}
+		}
+
+		// Auto OCO via short polling of open orders
+		if (autoOco && (takeProfitOrder || stopLossOrder)) {
+			const start = Date.now();
+			const tpId = takeProfitOrder && (takeProfitOrder.orderId || takeProfitOrder.clientOrderId || takeProfitOrder.orderId);
+			const slId = stopLossOrder && (stopLossOrder.orderId || stopLossOrder.clientOrderId || stopLossOrder.orderId);
+			let otherToCancel: any = null;
+			let handled = false;
+
+			while ((Date.now() - start) / 1000 < autoOcoTimeout) {
+				await sleep(1000);
+				try {
+					const open = await binanceClient.futuresOpenOrders({ symbol });
+					const openIds = (open || []).map((o: any) => String(o.orderId));
+
+					// if TP disappeared from open orders -> cancel SL
+					if (tpId && !openIds.includes(String(tpId))) {
+						if (slId) otherToCancel = slId;
+						handled = true;
+						break;
+					}
+					// if SL disappeared -> cancel TP
+					if (slId && !openIds.includes(String(slId))) {
+						if (tpId) otherToCancel = tpId;
+						handled = true;
+						break;
+					}
+				} catch (e) {
+					// transient error - ignore
+				}
+			}
+
+			if (otherToCancel) {
+				try {
+					await binanceClient.futuresCancelOrder({ symbol, orderId: otherToCancel } as any);
+					autoOcoResult = { status: 'cancelled', cancelledOrderId: otherToCancel };
+				} catch (e: any) {
+					autoOcoResult = { status: 'error', error: (e && e.message) ? e.message : e };
+				}
+			} else {
+				autoOcoResult = { status: 'timeout' };
+			}
+		}
+	}
+
+	// final response
+	const response = {
+		marketOrder,
+		takeProfitOrder,
+		stopLossOrder,
+		autoOcoResult,
+	};
+
+	return this.helpers.returnJsonArray(response as any);
 }

--- a/nodes/Binance/actions/future/order/order.properties.ts
+++ b/nodes/Binance/actions/future/order/order.properties.ts
@@ -34,6 +34,21 @@ export const properties: IBinanceFutureProperties = [
 		default: '',
 	},
 	{
+		displayName: 'Order Type',
+		name: 'orderType',
+		type: 'options',
+		required: true,
+		displayOptions: {
+			show: { resource: ['future'], operation: ['order'] },
+			hide: { side: ['CLEAR', 'GET'] },
+		},
+		options: [
+			{ name: 'LIMIT', value: 'LIMIT' },
+			{ name: 'MARKET', value: 'MARKET' },
+		],
+		default: 'LIMIT',
+	},
+	{
 		displayName: 'Quantity',
 		name: 'quantity',
 		type: 'number',
@@ -50,7 +65,8 @@ export const properties: IBinanceFutureProperties = [
 		type: 'number',
 		required: true,
 		displayOptions: {
-			show: { resource: ['future'], operation: ['order'] },
+			// Price only shown for LIMIT orders
+			show: { resource: ['future'], operation: ['order'], orderType: ['LIMIT'] },
 			hide: { side: ['CLEAR', 'GET'] },
 		},
 		default: 0,
@@ -64,5 +80,64 @@ export const properties: IBinanceFutureProperties = [
 			hide: { side: ['CLEAR', 'GET'] },
 		},
 		default: false,
+	},
+	{
+		displayName: 'Take Profit (%)',
+		name: 'tpPercent',
+		type: 'number',
+		default: 0,
+		displayOptions: {
+			show: { resource: ['future'], operation: ['order'] },
+			hide: { side: ['CLEAR', 'GET'] },
+		},
+		description: 'Take profit in percent (from entry price). 0 = disabled',
+	},
+	{
+		displayName: 'Stop Loss (%)',
+		name: 'slPercent',
+		type: 'number',
+		default: 0,
+		displayOptions: {
+			show: { resource: ['future'], operation: ['order'] },
+			hide: { side: ['CLEAR', 'GET'] },
+		},
+		description: 'Stop loss in percent (from entry price). 0 = disabled',
+	},
+	{
+		displayName: 'Auto OCO',
+		name: 'autoOco',
+		type: 'boolean',
+		default: true,
+		displayOptions: {
+			show: { resource: ['future'], operation: ['order'] },
+			hide: { side: ['CLEAR', 'GET'] },
+		},
+		description: 'If enabled, the node will monitor and cancel the paired TP/SL order after one triggers (short polling).',
+	},
+	{
+		displayName: 'Auto OCO Timeout (seconds)',
+		name: 'autoOcoTimeout',
+		type: 'number',
+		default: 30,
+		displayOptions: {
+			show: { resource: ['future'], operation: ['order'], autoOco: [true] },
+			hide: { side: ['CLEAR', 'GET'] },
+		},
+		description: 'How many seconds to wait for one conditional order to trigger before timing out.',
+	},
+	{
+		displayName: 'Working Type',
+		name: 'workingType',
+		type: 'options',
+		options: [
+			{ name: 'MARK_PRICE', value: 'MARK_PRICE' },
+			{ name: 'CONTRACT_PRICE', value: 'CONTRACT_PRICE' },
+		],
+		default: 'MARK_PRICE',
+		displayOptions: {
+			show: { resource: ['future'], operation: ['order'] },
+			hide: { side: ['CLEAR', 'GET'] },
+		},
+		description: 'Price to use for trigger evaluation (MARK_PRICE is recommended).',
 	},
 ];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-	"name": "n8n-nodes-binance",
-	"version": "0.0.4",
+	"name": "n8n-nodes-binance-plus",
+	"version": "0.0.1",
 	"description": "N8N nodes for Binance Exchange",
 	"keywords": [
 		"n8n-community-node-package"


### PR DESCRIPTION
Добавлена поддержка MARKET-входа и автоматического выставления TP/SL для фьючерсов (USDT-M).

Что реализовано:
- В UI Create Order (futures) добавлено поле Order Type: LIMIT | MARKET.
- Для MARKET: создаётся рыночный фьючерсный ордер; после получения цены входа (avgPrice) автоматически выставляются conditional orders:
  - TAKE_PROFIT_MARKET и/или STOP_MARKET с closePosition=true.
- TP/SL задаются в процентах от фактической цены входа (пример: Take Profit 5% — TP = entryPrice * 1.05).
- Реализована опция Auto OCO (по умолчанию true) — короткий polling open orders: при срабатывании одного условного ордера второй автоматически отменяется (таймаут по умолчанию 30s).
- Минимальные UI-изменения: добавлены поля tpPercent, slPercent, orderType, autoOco, autoOcoTimeout, workingType.
- package.json: пакет переименован в n8n-nodes-binance-plus, версия 0.0.1.

Ограничения / рекомендации:
- Auto OCO реализовано через короткий polling; для надёжной работы в продакшене рекомендуется вынести постоянный user-data websocket listener в Trigger/фоновой сервис.
- Не реализовано округление price/quantity по symbol filters (STEP_SIZE/tickSize) — рекомендую добавить в отдельном PR.
- Обязательно протестировать на Binance Futures Testnet перед использованием на mainnet.
